### PR TITLE
docs: simplify top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Programming Exercises
 
-A collection of small programming exercise projects and challenges implemented in C# targeting .NET 10. Each subfolder contains an individual project and often a project-specific README with more details.
+A collection of small C# projects and challenges implemented in C# targeting .NET 10. Each subfolder contains an individual project and often a project-specific README with more details.
 
 [![Build & Tests](https://github.com/zhollis21/ProgrammingExercises/actions/workflows/BuildAndTestProjectEuler.yml/badge.svg)](https://github.com/zhollis21/ProgrammingExercises/actions) [![.NET](https://img.shields.io/badge/.NET-10-brightgreen)](https://dotnet.microsoft.com/) [![License](https://img.shields.io/github/license/zhollis21/ProgrammingExercises)](LICENSE)
 
 ## Overview
 
-This repository hosts small C# projects used for learning and practicing algorithms and problem solving. The most complete project is `ProjectEuler`, which contains a console application and unit tests for various Project Euler problems.
+This repository hosts a collection of small C# projects used for learning and practicing algorithms and problem solving. Each project lives in its own subfolder and includes a project-specific README with build and run instructions.
 
 ## Projects
 
@@ -17,13 +17,7 @@ This repository hosts small C# projects used for learning and practicing algorit
 ## Quick start
 
 1. Install the .NET 10 SDK: https://dotnet.microsoft.com/
-2. From the repository root build everything:
-
-`dotnet build`
-
-3. Run the Project Euler console app:
-
-`dotnet run --project ProjectEuler/ProjectEuler.csproj`
+2. See the README inside each project folder for build, run, and test instructions specific to that project.
 
 ## License
 


### PR DESCRIPTION
Remove per-repo build/run/test commands from the top-level README and direct users to per-project READMEs.

Closes #5